### PR TITLE
MySQL 8 issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:18.04
 
 MAINTAINER Pierre-Yves Guerder <pierreyves.guerder@gmail.com>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ RUN echo "nameserver 1.1.1.1" | tee /etc/resolv.conf > /dev/null
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common && \
+    DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:ondrej/php && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    software-properties-common \
     git \
     ca-certificates \
     unzip \


### PR DESCRIPTION
Ubuntu 20.04 installs MySQL 8, 18.04 installs MySQL 5.*

Came across this issue when bumping our Symfony 5 project to PHP 7.4.

Obviously entirely up to you but for me just wanting to bump from your 7.2 pipeline to 7.4, shouldn't have a major database version change.